### PR TITLE
简化代码

### DIFF
--- a/services/document/query.py
+++ b/services/document/query.py
@@ -1,24 +1,17 @@
-from llama_index.legacy.retrievers import VectorIndexRetriever
-
-
 def query_results(index, query, min_score=0.80, top_k=10):
-    retriever = VectorIndexRetriever(index=index, similarity_top_k=top_k)
+    retriever = index.as_retriever(similarity_top_k=top_k)
 
     nodes = retriever.retrieve(query)
-    results = []
+    results = [
+        {
+            "uuid": node.metadata["uuid"],
+            "title": node.metadata["title"],
+            "snippet": node.metadata["snippet"],
+            "link": node.metadata["link"],
+            "content": node.text,
+            "score": node.score,
+        }
+        for node in nodes if node.score > min_score
+    ]
 
-    for node in nodes:
-        if node.score > min_score:
-            result = {
-                "uuid": node.metadata["uuid"],
-                "title": node.metadata["title"],
-                "snippet": node.metadata["snippet"],
-                "link": node.metadata["link"],
-                "content": node.text,
-                "score": node.score,
-            }
-            results.append(result)
-
-    sorted_results = sorted(results, key=lambda x: x["score"], reverse=True)
-
-    return sorted_results
+    return results

--- a/services/llm/gemini.py
+++ b/services/llm/gemini.py
@@ -1,0 +1,32 @@
+import os
+from llama_index.llms.gemini import Gemini
+from llama_index.embeddings.gemini import GeminiEmbedding
+from llama_index.core import ServiceContext
+
+
+def get_service_context():
+    api_key = os.getenv("GOOGLE_API_KEY")
+    api_base = os.getenv("GOOGLE_BASE_URL")
+    llm_model = os.getenv("GOOGLE_MODEL")
+    embed_model = os.getenv("GOOGLE_EMBED_MODEL")
+
+    llm_engine = Gemini(
+        model_name=llm_model, 
+        api_key=api_key, 
+        api_base=api_base
+    )
+
+    embed_engine = GeminiEmbedding(
+        model_name=embed_model, 
+        api_key=api_key, 
+        api_base=api_base
+    )
+
+    service_context = ServiceContext.from_defaults(
+        llm=llm_engine,
+        embed_model=embed_engine,
+    )
+    # set_global_service_context(service_context)
+    print("init service_context with apibase", api_base)
+
+    return service_context


### PR DESCRIPTION
简化了检索召回结果的代码
- llamaindex将原来代码中的导入和创建检索器封装成了VectorStoreIndex的一个函数as_retriever，于是我使用了llamaindex封装好的函数替换原代码。
- 用列表推导式优化循环流程，这样处理大量数据时更高效
- 删除了最后的按分数从高到低排序，因为原本就是排序完的，不需要再排序一次